### PR TITLE
Add github action to update all submodules each night

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,27 @@
+name: Update Submodules
+
+on:
+  # Run nightly: 8am UTC = 3am Eastern
+  schedule:
+  - cron: '0 8 * * *'
+  # Or run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  update-submodules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update all submodules
+        run: |
+          # initialize submodules at their current local version
+          git submodule update --init --recursive
+          
+          # update submodules to the latest remote version
+          git submodule update --remote --merge
+          
+          # commit and push it
+          git config user.email "action@github.com"
+          git config user.name "GitHub Actions"
+          git commit -am "Updated submodules $(date)"
+          git push


### PR DESCRIPTION
This is the first step towards a nightly build as described here: https://github.com/TriForceX/MiyooCFW/discussions/336

The action runs automatically at 3am Eastern, but it can also be triggered manually from the actions tab if you don't want to wait.