### PR TITLE
Nightly build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: echo "::set-output name=version::$GITHUB_REF_NAME-$(git rev-parse --short HEAD)"
+      id: version
+    - run: echo "Version ${{ steps.version.outputs.version }}"
     - uses: actions/download-artifact@v3
     - run: find .
     - name: Replace files under sdcard with the ones we just built
@@ -182,10 +185,14 @@ jobs:
     - run: find .
     
     # https://github.com/MiyooCFW/sdcard/blob/master/.github/workflows/build.yml
-    - run: cd sdcard && sudo ./generate_image_file.sh
+    - name: Build image
+      run: |
+          cd sdcard
+          export VERSION=${{ steps.version.outputs.version }}
+          sudo ./generate_image_file.sh
     - uses: actions/upload-artifact@v2
       with:
-        name: MiyooCFW microSD image
+        name: "cfw-${{ steps.version.outputs.version }}.img"
         path: sdcard/cfw-*.img
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
 
@@ -203,6 +210,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: echo "::set-output name=version::$GITHUB_REF_NAME-$(git rev-parse --short HEAD)-mixed"
+      id: version
+    - run: echo "Version ${{ steps.version.outputs.version }}"
     - uses: actions/download-artifact@v3
     - run: find .
     - name: Replace files under sdcard with the ones we just built
@@ -223,9 +233,13 @@ jobs:
     - run: find .
     
     # https://github.com/MiyooCFW/sdcard/blob/master/.github/workflows/build.yml
-    - run: cd sdcard && sudo ./generate_image_file.sh
+    - name: Build image
+      run: |
+          cd sdcard
+          export VERSION=${{ steps.version.outputs.version }}
+          sudo ./generate_image_file.sh
     - uses: actions/upload-artifact@v2
       with:
-        name: MiyooCFW microSD image with old uboot and rootfs
+        name: "cfw-${{ steps.version.outputs.version }}.img"
         path: sdcard/cfw-*.img
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
         mv boot-logo-powkiddy/boot-logo sdcard/boot/variants/v90_q90/
         mv daemon/daemon sdcard/boot/variants/v90_q90/
         rm -rf sdcard/main/gmenu2x/
-        unzip gmenunx/GMenuNX.zip -d sdcard/main/gmenu2x/
+        unzip gmenunx/GMenuNX.zip -d sdcard/main/
         
         # todo: other variants
     - run: find .
@@ -228,7 +228,7 @@ jobs:
         mv boot-logo-powkiddy/boot-logo sdcard/boot/variants/v90_q90/
         mv daemon/daemon sdcard/boot/variants/v90_q90/
         rm -rf sdcard/main/gmenu2x/
-        unzip gmenunx/GMenuNX.zip -d sdcard/main/gmenu2x/
+        unzip gmenunx/GMenuNX.zip -d sdcard/main/
   
     - run: find .
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,8 +178,7 @@ jobs:
         mv buildroot/rootfs.tar.xz sdcard/rootfs.tar.xz 
         mv boot-logo-powkiddy/boot-logo sdcard/boot/variants/v90_q90/
         mv daemon/daemon sdcard/boot/variants/v90_q90/
-        rm -rf sdcard/main/gmenu2x/
-        unzip gmenunx/GMenuNX.zip -d sdcard/main/
+        unzip -o gmenunx/GMenuNX.zip -d sdcard/main/
         
         # todo: other variants
     - run: find .
@@ -227,8 +226,7 @@ jobs:
         mv kernel/*.ko sdcard/boot/variants/v90_q90/
         mv boot-logo-powkiddy/boot-logo sdcard/boot/variants/v90_q90/
         mv daemon/daemon sdcard/boot/variants/v90_q90/
-        rm -rf sdcard/main/gmenu2x/
-        unzip gmenunx/GMenuNX.zip -d sdcard/main/
+        unzip -o gmenunx/GMenuNX.zip -d sdcard/main/
   
     - run: find .
     

--- a/.github/workflows/nightly-update-build.yml
+++ b/.github/workflows/nightly-update-build.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   update-submodules:
+    # only run on the main repo; forks can pull changes from there
+    if: github.repository == 'TriForceX/MiyooCFW'
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:


### PR DESCRIPTION
* Only run the update job on the main repo (so that my fork stops getting out-of-sync with the main repo)
* Set version from *this* repo instead of the sdcard repo - goes with https://github.com/MiyooCFW/sdcard/pull/4
  * I also changed the format to be branch-hash or tag-hash because seeing version 1.3.3-28-hash could be confusing
* Fix GmenuNX unzip path and keep the other content
  * With this one, the -mixed image boots into GmenuNX, but the controls are still all messed up.