### PR TITLE
More build tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,7 @@ jobs:
         git submodule update --init --recursive -- kernel
         cd kernel
         make miyoo_defconfig 
-        make zImage
-        make M=$PwD
+        make
         mkdir dist
         mv arch/arm/boot/dts/suniv-f1c500s-miyoo.dtb dist/
         mv arch/arm/boot/zImage dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        git submodule update --init --recursive -- buildroot
+        git submodule update --init --recursive --depth 1 -- buildroot
         cd buildroot
         make
         cd output/images/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,6 @@ jobs:
     - boot-scr
     - kernel
     - logo
-    - daemon
     - gmenunx
     runs-on: ubuntu-latest
     steps:
@@ -224,7 +223,6 @@ jobs:
         mv kernel/zImage sdcard/boot/variants/v90_q90/
         mv kernel/*.ko sdcard/boot/variants/v90_q90/
         mv boot-logo-powkiddy/boot-logo sdcard/boot/variants/v90_q90/
-        mv daemon/daemon sdcard/boot/variants/v90_q90/
         unzip -o gmenunx/GMenuNX.zip -d sdcard/main/
   
     - run: find .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        git submodule update --init --recursive --depth 1 -- buildroot
+        git submodule update --init --depth 1 -- buildroot
         cd buildroot
         make
         cd output/images/


### PR DESCRIPTION
Another batch of improvements:

* Build the kernel and modules together. Turned out not to solve the input issue, but still seems better in general
* Lighten the buildroot submodule chekout. Seems to improve build times.
* Skip daemon in mixed build. Should avoid input issues and finally get us a working image out of the CI build.