### PR TITLE
Make nightly job only responsible for updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,8 @@
 # based on https://github.com/Arcnor/MiyooCFW/blob/ci/.github/workflows/main.yml
 name: Build
 
-# Run on changes (including automated ones from the update job), allow manual triggering from the Actions tab, and allow triggering from update job
-on: [push, pull_request, workflow_dispatch, workflow_call]
-
-# todo: figure out how to use reusable workflows or actions or something to reduce the amount of
-# duplication between this and the submodule's build configurations
+# Run on changes (including automated ones from the update job), allow manual triggering from the Actions tab
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
 

--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -1,4 +1,4 @@
-name: Update & Build
+name: Update Submodules
 
 on:
   # Run nightly: 8am UTC = 3am Eastern
@@ -12,17 +12,16 @@ jobs:
     # only run on the main repo; forks can pull changes from there
     if: github.repository == 'TriForceX/MiyooCFW'
     runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      changes: ${{ steps.update.outputs.changes }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Github Personal Access Token
+          # needed because pushes with the deafult GITHUB_TOKEN won't trigger the build step
+          token: ${{ secrets.GH_PAT }}
+          submodules: true
       - name: Update all submodules
         id: update
         run: |
-          # initialize submodules at their current local version
-          git submodule update --init --recursive
-          
           # update submodules to the latest remote version
           git submodule update --remote --merge
           
@@ -35,9 +34,4 @@ jobs:
           git config user.name "GitHub Actions"
           git commit -am "Updated submodules $(date)"
           git push
-  # note: the git push in the update submodules step uses the built-in GITHUB_TOKEN, which is not allowed to trigger
-  # other workflows, such as our build.yml, so we have to call it explicitly here.
-  build:
-    needs: update-submodules
-    if: ${{ needs.update-submodules.outputs.changes}}
-    uses: ./.github/workflows/build.yml
+


### PR DESCRIPTION
This switches the nightly update to using a personal access token, instead of the built-in `GITHUB_TOKEN`.

The `GITHUB_TOKEN` is special in that when it is used to push code, it does not trigger any other workflow that would normally happen on push. Because of that limitation, we had turned the build workflow into a reusable workflow and called it explicitly from the nightly update.

But, that causes another limitation: reusable workflows cannot call other reusable workflows, which meant that we had to define the build jobs for all of the submodules twice: in the submodule, and again here.

With this change, we can now make the submodule builds into reusable workflows and just call them with a single line from the mega-build here instead of having to define everything twice.

**BEFORE MERGING THIS, please set up a Personal Access Token in a Repository secret:**

1. Go to https://github.com/settings/tokens 
	  * Click Generate a new token
	  * Name: "for MiyooCFW nightly submodule update" or similar
	  * Expiration: No expiration
	  * Select scopes: `repo`
	  * Click Generate token
2. In a new tab, go to https://github.com/TriForceX/MiyooCFW/settings/secrets/actions
	  * Click New repository secret
	  * Name: `GH_PAT`
	  * Value: copy and paste the token from step 1
