### PR TITLE
Use reusable workflow with caching for the kernel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,29 +41,11 @@ jobs:
         path: sdcard/boot/boot.scr
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
 
-  # https://github.com/MiyooCFW/kernel/blob/master/.github/workflows/c-cpp.yml
   # todo: 1-bit sd card variant
   kernel:
-    runs-on: ubuntu-20.04
-    container:
-      image: miyoocfw/toolchain:master
-    steps:
-    - uses: actions/checkout@v2
-    - run: |
-        git submodule update --init --recursive -- kernel
-        cd kernel
-        make miyoo_defconfig 
-        make
-        mkdir dist
-        mv arch/arm/boot/dts/suniv-f1c500s-miyoo.dtb dist/
-        mv arch/arm/boot/zImage dist/
-        mv drivers/video/fbdev/core/*.ko dist/
-        mv drivers/video/fbdev/r61520fb.ko dist/
-    - uses: actions/upload-artifact@v2
-      with:
-        name: kernel
-        path: kernel/dist/*
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    uses: MiyooCFW/kernel/.github/workflows/build.yml@master
+    with:
+      submodule: kernel
         
   # todo: use buildroot for more than just the rootfs
   buildroot:


### PR DESCRIPTION
This combined with the buildroot caching should significantly improve the speed of most CI builds