### PR TITLE
fix nightly update for real

### DIFF
--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -18,10 +18,13 @@ jobs:
           # Github Personal Access Token
           # needed because pushes with the deafult GITHUB_TOKEN won't trigger the build step
           token: ${{ secrets.GH_PAT }}
-          submodules: true
+          # do NOT set submodules: true here - it does a funky checkout that keeps updating from working
+
       - name: Update all submodules
         id: update
         run: |
+          git submodule init
+          
           # update submodules to the latest remote version
           git submodule update --remote --merge
           


### PR DESCRIPTION
I had switched to using the `submodules: true` option on the github checkouts action, but that does something fancy to reduce the download size, which has a side effect of breaking updates. So, kinda the opposite of what we need here.

I rolled it back to a simple `git submodule init` and now it appears to be working again.

This is the more thorough fix to follow up the previous band-aid: https://github.com/TriForceX/MiyooCFW/pull/355