### PR TITLE
fix .img filename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,8 +158,7 @@ jobs:
     - name: Build image
       run: |
           cd sdcard
-          export VERSION=${{ steps.version.outputs.version }}
-          sudo ./generate_image_file.sh
+          sudo VERSION=${{ steps.version.outputs.version }} ./generate_image_file.sh
     - uses: actions/upload-artifact@v2
       with:
         name: "cfw-${{ steps.version.outputs.version }}.img"
@@ -205,8 +204,7 @@ jobs:
     - name: Build image
       run: |
           cd sdcard
-          export VERSION=${{ steps.version.outputs.version }}
-          sudo ./generate_image_file.sh
+          sudo VERSION=${{ steps.version.outputs.version }} ./generate_image_file.sh
     - uses: actions/upload-artifact@v2
       with:
         name: "cfw-${{ steps.version.outputs.version }}.img"


### PR DESCRIPTION
The name of the download, which becomes the name of the .zip file was correct, but the name of the actual .img file inside the .zip was incorrect - it was ignoring the version env var (for the overall image version) and instead using the version of the sdcard repo.