### PR TITLE
fix action builds from kernel submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,11 +154,11 @@ jobs:
         # instead uses different kernel builds to handle different keyboards 🤷
         # (aside from the display panel and input configuration, the rest of the 
         # hardware is pretty similar. The panel is a random mix-n-match.)
-        mv kernel/suniv-f1c500s-miyoo.dtb sdcard/boot/ 
+        mv kernel (uClibc)/suniv-f1c500s-miyoo.dtb sdcard/boot/ 
         
         # kernel
-        mv kernel/zImage sdcard/boot/
-        mv kernel/*.ko sdcard/boot/
+        mv kernel (uClibc)/zImage sdcard/boot/
+        mv kernel (uClibc)/*.ko sdcard/boot/
         
         # currently linux can't boot if we use the rootfs that we build
         # once we fix the video issues, this should hopefully be easier to debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,11 +154,11 @@ jobs:
         # instead uses different kernel builds to handle different keyboards 🤷
         # (aside from the display panel and input configuration, the rest of the 
         # hardware is pretty similar. The panel is a random mix-n-match.)
-        mv kernel (uClibc)/suniv-f1c500s-miyoo.dtb sdcard/boot/ 
+        mv kernel\ \(uClibc\)/suniv-f1c500s-miyoo.dtb sdcard/boot/ 
         
         # kernel
-        mv kernel (uClibc)/zImage sdcard/boot/
-        mv kernel (uClibc)/*.ko sdcard/boot/
+        mv kernel\ \(uClibc\)/zImage sdcard/boot/
+        mv kernel\ \(uClibc\)/*.ko sdcard/boot/
         
         # currently linux can't boot if we use the rootfs that we build
         # once we fix the video issues, this should hopefully be easier to debug


### PR DESCRIPTION
We're building [kernel](https://github.com/MiyooCFW/kernel) modules from git submodule instructions instead of specifying it [here](https://github.com/TriForceX/MiyooCFW/blob/8c029fb5ef6d6200d926a39b5e421da5412a4e81/.github/workflows/build.yml#L47). Considering that every change made to naming of [distribution build](https://github.com/MiyooCFW/kernel/blob/2faaa4a0bd18e2f4efa6e9e7c79354494e620d59/.github/workflows/build.yml#L66) should be included in main MiyooCFW repo workflow file.