### PR TITLE
Continue workflow regardless of docker jobs error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       submodule: buildroot
       
   docker-uclibc:
+    continue-on-error: true
     needs: build-image
     permissions:
       contents: read
@@ -70,6 +71,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
   docker-musl:
+    continue-on-error: true
     needs: build-image
     permissions:
       contents: read


### PR DESCRIPTION
Continue auto-buld even if the owner/user lack docker credentials.
Enabling this in case anyone want to run whole build from their repo out of upstream (for e.g. test runs).